### PR TITLE
Add CrimeIncident class

### DIFF
--- a/lib/adapters/crime_incident.rb
+++ b/lib/adapters/crime_incident.rb
@@ -1,0 +1,69 @@
+class CrimeIncident
+  SOCRATA_ENDPOINT = 'http://data.sfgov.org/resource/tmnf-yvry.json'
+
+# Text from https://github.com/citygram/citygram-services/issues/23
+TITLE_TEMPLATE = <<-CFA.gsub(/\s*\n/,' ').chomp(' ')
+A crime incident happened near you on %{date} at %{address}. The SFPD
+described it as a %{descript} with the following resolution: %{resolution}.
+CFA
+
+  def self.query_url
+    url = URI(SOCRATA_ENDPOINT)
+
+    url.query = Faraday::Utils.build_query(
+      '$order' => 'date DESC',
+      '$limit' => 100,
+      '$where' => "date > '#{(DateTime.now - 19).iso8601}'"
+    )
+    url.to_s
+  end
+
+  def initialize(record, cache=nil)
+    @record = record
+    @cache = cache
+  end
+
+  # Helper method to make the dates look nice in the "fancy title".
+  def date_cleanup(date_str)
+    date_str.gsub!(/T[\d\:]+$/,'')
+    Time.parse(date_str).strftime("%b %-e, %Y")
+  end
+
+  def fancy_title
+    # Apply any transformations needed to the text being sent to our
+    # title "mad lib" above.
+    title_pieces = {
+      :date => date_cleanup(@record['date']),
+      :address => Utils.titleize(@record['address']),
+      :descript => Utils.titleize(@record['descript']),
+      :resolution => @record['resolution'].downcase
+    }
+
+    TITLE_TEMPLATE % title_pieces
+  end
+
+  def location
+    @record['location']
+  end
+
+  def as_geojson_feature
+    # We're trying to return geojson records, so return nil if
+    # we don't have a location.
+    return nil if location.nil?
+
+    # Return the feature as a hash, which we will convert to json.
+    {
+      'id' => @record['incidntnum'],
+      'type' => 'Feature',
+      'properties' => @record.merge('title' => fancy_title),
+      'geometry' => {
+        'type' => 'Point',
+        'coordinates' => [
+          location['longitude'].to_f,
+          location['latitude'].to_f
+        ]
+      }
+    }
+  end
+
+end

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -17,7 +17,8 @@ geocoder_cache = HashCache.new
 adapters = {
   'street-use-permits' => StreetUsePermit,
   'food-truck-permits' => FoodTruckPermit,
-  'new-business-location' => NewBusinessLocation
+  'new-business-location' => NewBusinessLocation,
+  'crime-incidents' => CrimeIncident
 }
 
 get '/' do

--- a/spec/adapters/crime_incident_spec.rb
+++ b/spec/adapters/crime_incident_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+response_fixture = <<-JMM
+{
+  "time" : "23:50",
+  "category" : "ASSAULT",
+  "pddistrict" : "MISSION",
+  "pdid" : "15011294504134",
+  "location" : {
+    "needs_recoding" : false,
+    "longitude" : "-122.419671780296",
+    "latitude" : "37.7650501214668",
+    "human_address" : {\"address\":\"\",\"city\":\"\",\"state\":\"\",\"zip\":\"\"}
+  },
+  "address" : "16TH ST / MISSION ST",
+  "descript" : "BATTERY",
+  "dayofweek" : "Thursday",
+  "resolution" : "NONE",
+  "date" : "2015-02-05T00:00:00",
+  "y" : "37.7650501214668",
+  "x" : "-122.419671780296",
+  "incidntnum" : "150112945"
+}
+JMM
+
+describe CrimeIncident do
+  let(:api_response) { JSON.parse(response_fixture) }
+
+  describe "#fancy_title" do
+    it "returns the nicely formatted title message" do
+      crime_incident = CrimeIncident.new(api_response)
+      exp_title = "A crime incident happened near you on Feb 5, 2015 at 16th St / Mission St. The SFPD described it as a Battery with the following resolution: None."
+      expect(crime_incident.fancy_title).to eq(exp_title)
+    end
+  end
+
+  describe "#as_geojson_feature" do
+    context "there is no location information" do
+      it "returns nil" do
+        crime_incident = CrimeIncident.new(api_response)
+        allow(crime_incident).to receive(:location) { nil }
+        expect(crime_incident.as_geojson_feature).to be_nil
+      end
+    end
+
+    context "location information exists" do
+      it "returns the proper geojson feature" do
+        crime_incident = CrimeIncident.new(api_response)
+        allow(crime_incident).to receive(:location) do
+          { "longitude" => "-122.419671780296", "latitude" => "37.7650501214668" }
+        end
+
+        exp_geojson = {
+          'id' => '150112945',
+          'type' => 'Feature',
+          'properties' => api_response.merge('title' => crime_incident.fancy_title),
+          'geometry' => {
+            'type' => 'Point',
+            'coordinates' => [-122.419671780296, 37.7650501214668]
+          }
+        }
+        expect(crime_incident.as_geojson_feature).to eq(exp_geojson)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add an adapter for the [SFPD Crime Incidents endpoint](https://data.sfgov.org/Public-Safety/SFPD-Incidents-from-1-January-2003/tmnf-yvry).