### PR TITLE
Refactor the Socrata adapters into subclasses of a base adapter

### DIFF
--- a/lib/adapters/crime_incident.rb
+++ b/lib/adapters/crime_incident.rb
@@ -1,4 +1,4 @@
-class CrimeIncident
+class CrimeIncident < SocrataBase
   SOCRATA_ENDPOINT = 'http://data.sfgov.org/resource/tmnf-yvry.json'
 
 # Text from https://github.com/citygram/citygram-services/issues/23
@@ -18,17 +18,6 @@ CFA
     url.to_s
   end
 
-  def initialize(record, cache=nil)
-    @record = record
-    @cache = cache
-  end
-
-  # Helper method to make the dates look nice in the "fancy title".
-  def date_cleanup(date_str)
-    date_str.gsub!(/T[\d\:]+$/,'')
-    Time.parse(date_str).strftime("%b %-e, %Y")
-  end
-
   def fancy_title
     # Apply any transformations needed to the text being sent to our
     # title "mad lib" above.
@@ -40,10 +29,6 @@ CFA
     }
 
     TITLE_TEMPLATE % title_pieces
-  end
-
-  def location
-    @record['location']
   end
 
   def as_geojson_feature

--- a/lib/adapters/food_truck_permit.rb
+++ b/lib/adapters/food_truck_permit.rb
@@ -1,4 +1,4 @@
-class FoodTruckPermit
+class FoodTruckPermit < SocrataBase
   SOCRATA_ENDPOINT = 'http://data.sfgov.org/resource/rqzj-sfat.json'
 
   # Text from https://github.com/citygram/citygram-services/issues/8
@@ -17,10 +17,6 @@ CFA
       '$where' => "approved > '#{(DateTime.now - 7).iso8601}'"
     )
     url.to_s
-  end
-
-  def initialize(record, cache=nil)
-    @record = record
   end
 
   def fancy_title
@@ -46,10 +42,6 @@ CFA
   def food_items
     str = @record['fooditems'].dup
     str.gsub(":",",")
-  end
-
-  def location
-    @record['location']
   end
 
   def as_geojson_feature

--- a/lib/adapters/new_business_location.rb
+++ b/lib/adapters/new_business_location.rb
@@ -1,4 +1,4 @@
-class NewBusinessLocation
+class NewBusinessLocation < SocrataBase
   SOCRATA_ENDPOINT = 'http://data.sfgov.org/resource/g8m3-pdis.json'
 
   # Text from https://github.com/citygram/citygram-services/issues/25
@@ -17,10 +17,6 @@ CFA
     url.to_s
   end
 
-  def initialize(record, cache=nil)
-    @record = record
-  end
-
   def fancy_title
     title_pieces = {
       :dba_name => Utils.titleize(@record['dba_name']),
@@ -36,10 +32,6 @@ CFA
     else
       "#{@record['full_business_address']}, #{@record['city']}, #{@record['state']}"
     end
-  end
-
-  def location
-    @record['location']
   end
 
   def as_geojson_feature

--- a/lib/adapters/socrata_base.rb
+++ b/lib/adapters/socrata_base.rb
@@ -1,0 +1,17 @@
+class SocrataBase
+  def initialize(record, cache=nil)
+    @record = record
+    @cache = cache
+  end
+
+  # Helper method to make the dates look nice in the "fancy title".
+  def date_cleanup(date_str, format_string="%b %-e, %Y")
+    date_str.gsub!(/T[\d\:]+$/,'')
+    Time.parse(date_str).strftime(format_string)
+  end
+
+  def location
+    @record['location']
+  end
+
+end

--- a/lib/adapters/street_use_permit.rb
+++ b/lib/adapters/street_use_permit.rb
@@ -1,4 +1,4 @@
-class StreetUsePermit
+class StreetUsePermit < SocrataBase
   SOCRATA_ENDPOINT = 'http://data.sfgov.org/resource/b6tj-gt35.json'
 
 # Text from https://github.com/citygram/citygram-services/issues/24
@@ -25,17 +25,6 @@ CFA
       " AND approved_date > '#{(DateTime.now - 7).iso8601}'"
     )
     url.to_s
-  end
-
-  def initialize(record, cache)
-    @record = record
-    @cache = cache
-  end
-
-  # Helper method to make the dates look nice in the "fancy title".
-  def date_cleanup(date_str)
-    date_str.gsub!(/T[\d\:]+$/,'')
-    Time.parse(date_str).strftime("%b %-e, %Y")
   end
 
   def fancy_title

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -1,3 +1,4 @@
+require File.join(File.dirname(__FILE__), 'adapters', 'socrata_base')
 Dir[File.join(File.dirname(__FILE__), 'adapters', '*.rb')].each { |file| require file }
 require File.join(File.dirname(__FILE__), 'hash_cache')
 require File.join(File.dirname(__FILE__), 'utils')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'sinatra'
 require 'rack/test'
 require 'vcr'
 
+
 # Require any support files (i.e. custom matchers)
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each{ |f| require f }
 


### PR DESCRIPTION
I saw an opportunity to DRY up the adapters. SF has a Socrata data portal, so there is a lot of common code between adapters.