### PR TITLE
Create endpoint for eviction notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ All active endpoints can be seen at the [root (/)](https://citygram-sf-registrie
 * [/food-truck-permits](https://citygram-sf-registries.herokuapp.com/food-truck-permits) - from [sfdata.gov](https://data.sfgov.org/Economy-and-Community/Mobile-Food-Facility-Permit/rqzj-sfat)
 * [/new-business-locations](https://citygram-sf-registries.herokuapp.com/new-business-locations) - from [sfdata.gov](https://data.sfgov.org/Economy-and-Community/Open-Business-Locations-San-Francisco/g8m3-pdis)
 * [/crime-incidents](https://citygram-sf-registries.herokuapp.com/crime-incidents) - from [sfdata.gov](http://data.sfgov.org/resource/tmnf-yvry)
+* [/eviction-notices](https://citygram-sf-registries.herokuapp.com/eviction-notices) - from [data.sfgov.org](https://data.sfgov.org/Housing-and-Buildings/Eviction-Notices/5cei-gny5)
 
 **Technical note:** The endpoints with the \* above are written in the style discussed in the [getting started guide](http://bit.ly/citygramsf). The others have been designed to be their own class (there is still work to do here).  Either method works fine.
 

--- a/lib/adapters/eviction_notice.rb
+++ b/lib/adapters/eviction_notice.rb
@@ -1,5 +1,5 @@
 class EvictionNotice < SocrataBase
-  SOCRATA_ENDPOINT = 'http://data.sfgov.org/resource/tmnf-yvry.json'
+  SOCRATA_ENDPOINT = 'http://data.sfgov.org/resource/5cei-gny5.json'
 
 TITLE_TEMPLATE = <<-CFA.gsub(/\s*\n/,' ').chomp(' ')
 An eviction notice was filed near you on %{date} for %{address}. The notice
@@ -30,7 +30,7 @@ CFA
     url.query = Faraday::Utils.build_query(
       '$order' => 'file_date DESC',
       '$limit' => 100,
-      '$where' => "file_date > '#{(DateTime.now - 19).iso8601}'"
+      '$where' => "file_date > '#{(DateTime.now - 45).iso8601}'"
     )
     url.to_s
   end

--- a/lib/adapters/eviction_notice.rb
+++ b/lib/adapters/eviction_notice.rb
@@ -15,7 +15,7 @@ CFA
     "access_denial" => "unlawful denial of access to unit",
     "unapproved_subtenant" => "the tenant had an unapproved subtenant",
     "owner_move_in" => "the owner is moving in",
-    "demolition" => "demolistion of the property",
+    "demolition" => "demolition of the property",
     "capital_improvement" => "a capital improvement",
     "substantial_rehab" => "substantial rehabilitaion",
     "ellis_act_withdrawal" => "an Ellis Act withdrawal (going out of business)",

--- a/lib/adapters/eviction_notice.rb
+++ b/lib/adapters/eviction_notice.rb
@@ -1,0 +1,85 @@
+class EvictionNotice < SocrataBase
+  SOCRATA_ENDPOINT = 'http://data.sfgov.org/resource/tmnf-yvry.json'
+
+TITLE_TEMPLATE = <<-CFA.gsub(/\s*\n/,' ').chomp(' ')
+An eviction notice was filed near you on %{date} for %{address}. The notice
+listed %{reason} as the grounds for eviction.
+CFA
+
+  REASON_MAPPINGS = {
+    "non_payment" => "non-payment of rent",
+    "breach" => "breach of lease",
+    "nuisance" => "nuisance",
+    "illegal_use" => "an illegal use of the rental unit",
+    "failure_to_sign_renewal" => "failure to sign a lease renewal",
+    "access_denial" => "unlawful denial of access to unit",
+    "unapproved_subtenant" => "the tenant had an unapproved subtenant",
+    "owner_move_in" => "the owner is moving in",
+    "demolition" => "demolistion of the property",
+    "capital_improvement" => "a capital improvement",
+    "substantial_rehab" => "substantial rehabilitaion",
+    "ellis_act_withdrawal" => "an Ellis Act withdrawal (going out of business)",
+    "condo_conversion" => "a condo conversion",
+    "roomate_same_unit" => "evicting a roomate",
+    "other_cause" => "a non-standard reason"
+  }
+
+  def self.query_url
+    url = URI(SOCRATA_ENDPOINT)
+
+    url.query = Faraday::Utils.build_query(
+      '$order' => 'file_date DESC',
+      '$limit' => 100,
+      '$where' => "file_date > '#{(DateTime.now - 19).iso8601}'"
+    )
+    url.to_s
+  end
+
+  def fancy_title
+    # Apply any transformations needed to the text being sent to our
+    # title "mad lib" above.
+    title_pieces = {
+      :date => date_cleanup(@record['file_date']),
+      :address => Utils.titleize(@record['address']).gsub(/\s+/, ' '),
+      :reason => translate_reason
+    }
+
+    TITLE_TEMPLATE % title_pieces
+  end
+
+  def as_geojson_feature
+    # We're trying to return geojson records, so return nil if
+    # we don't have a location.
+    return nil if location.nil?
+
+    # Return the feature as a hash, which we will convert to json.
+    {
+      'id' => @record['eviction_id'],
+      'type' => 'Feature',
+      'properties' => @record.merge('title' => fancy_title),
+      'geometry' => {
+        'type' => 'Point',
+        'coordinates' => [
+          location['longitude'].to_f,
+          location['latitude'].to_f
+        ]
+      }
+    }
+  end
+
+  def location
+    @record['client_location']
+  end
+
+  private
+
+  def translate_reason
+    REASON_MAPPINGS.each do |k, v|
+      if @record[k] == true
+        return v
+      end
+    end
+
+    "no reason"
+  end
+end

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -19,7 +19,8 @@ adapters = {
   'street-use-permits' => StreetUsePermit,
   'food-truck-permits' => FoodTruckPermit,
   'new-business-location' => NewBusinessLocation,
-  'crime-incidents' => CrimeIncident
+  'crime-incidents' => CrimeIncident,
+  'eviction-notices' => EvictionNotice,
 }
 
 get '/' do
@@ -98,8 +99,6 @@ get '/tow-away-zones' do
   JSON.pretty_generate('type' => 'FeatureCollection', 'features' => features)
 end
 
-
-
 # Create routes for all the keys in the adapters hash.
 get /(#{adapters.keys.join('|')})/ do
   adapter_class = adapters[params[:captures].first]
@@ -109,6 +108,7 @@ get /(#{adapters.keys.join('|')})/ do
   begin
     # Query the data.sfgov.org endpoint
     response = connection.get
+
     # Parse the json response
     collection = JSON.parse(response.body)
 

--- a/spec/adapters/eviction_notice_spec.rb
+++ b/spec/adapters/eviction_notice_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+response_fixture = <<-JMM
+{
+  "other_cause": false,
+  "failure_to_sign_renewal": false,
+  "demolition": false,
+  "ellis_act_withdrawal": false,
+  "development": false,
+  "state": "CA",
+  "city": "San Francisco",
+  "client_location": {
+    "needs_recoding": false,
+    "longitude": "-122.413273080076",
+    "latitude": "37.7914675528019",
+    "human_address": {\"address\":\"\",\"city\":\"\",\"state\":\"\",\"zip\":\"\"}
+  },
+  "breach": false,
+  "owner_move_in": true,
+  "access_denial": false,
+  "non_payment": false,
+  "lead_remediation": false,
+  "roommate_same_unit": false,
+  "zip": "94108",
+  "capital_improvement": false,
+  "condo_conversion": false,
+  "neighborhood": "Nob Hill",
+  "constraints": "0",
+  "file_date": "2015-06-30T00:00:00",
+  "nuisance": false,
+  "eviction_id": "M151616",
+  "supervisor_district": "3",
+  "illegal_use": false,
+  "constraints_date": "2018-06-27T00:00:00",
+  "unapproved_subtenant": false,
+  "late_payments": false,
+  "address": "1100 Block of California  Street",
+  "substantial_rehab": false
+}
+JMM
+
+describe EvictionNotice do
+  let(:api_response) { JSON.parse(response_fixture) }
+
+  describe "#fancy_title" do
+    it "returns the nicely formatted title message" do
+      subject = EvictionNotice.new(api_response)
+      exp_title = "An eviction notice was filed near you on Jun 30, 2015 for 1100 Block Of California Street. The notice listed the owner is moving in as the grounds for eviction."
+      expect(subject.fancy_title).to eq(exp_title)
+    end
+  end
+
+  describe "#as_geojson_feature" do
+    context "there is no location information" do
+      it "returns nil" do
+        subject = EvictionNotice.new(api_response)
+        allow(subject).to receive(:location) { nil }
+        expect(subject.as_geojson_feature).to be_nil
+      end
+    end
+
+    context "location information exists" do
+      it "returns the proper geojson feature" do
+        subject = EvictionNotice.new(api_response)
+        allow(subject).to receive(:location) do
+          { "longitude" => "-122.419671780296", "latitude" => "37.7650501214668" }
+        end
+
+        exp_geojson = {
+          'id' => 'M151616',
+          'type' => 'Feature',
+          'properties' => api_response.merge('title' => subject.fancy_title),
+          'geometry' => {
+            'type' => 'Point',
+            'coordinates' => [-122.419671780296, 37.7650501214668]
+          }
+        }
+        expect(subject.as_geojson_feature).to eq(exp_geojson)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adapter uses the [Eviction Notices](https://data.sfgov.org/Housing-and-Buildings/Eviction-Notices/5cei-gny5) dataset from data.sfgov.org.

It works just like the rest of the socrata adapters in this repo. The
only notable difference is that I made a mapping of reasons for
evictions that turn them into more human text (I'm not a eviction
expert, so I copied most of the text from the tooltips on the socrata
page for this data).

Tests included.
